### PR TITLE
Update check.py bcz of char array default value cannot matched

### DIFF
--- a/CPS 2231 Labs/Lab3/Lab3 Student Download Code/check.py
+++ b/CPS 2231 Labs/Lab3/Lab3 Student Download Code/check.py
@@ -157,6 +157,8 @@ def check_output(output, expected_output, lab, test_case_desc):
     """Check if the output matches the expected pattern."""
     current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     answer_sheet = load_answer_sheet()
+    
+expected_output = expected_output.replace(r"\s*", r"[\s\u0000]*")
 
     if lab == "Lab3_3":
         pattern = re.compile(expected_output, re.DOTALL)


### PR DESCRIPTION
In the past file, you have to initialize each element with a blank space. The check.py should include \u0000 case. [\\s\\u0000]*  Bcz \s is the wildcard of ' ' \t \n \r \f \v.
![image](https://github.com/user-attachments/assets/d0457f23-cf4b-44a6-95d6-960c176e12f2)
![image](https://github.com/user-attachments/assets/ecdf6f29-e8f6-405f-8e0f-fa62e0b533cf)
![image](https://github.com/user-attachments/assets/474cbe01-e0d5-4460-b160-c4242450f5d9)
